### PR TITLE
Update PHP version requirement in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,18 +1,9 @@
 {
   "name": "krowinski/php-mysql-replication",
   "description": "Pure PHP Implementation of MySQL replication protocol. This allow you to receive event like insert, update, delete with their data and raw SQL queries.",
-  "keywords": [
-    "mysql-replication",
-    "php-library",
-    "mysql",
-    "mysql-binlog",
-    "mysql-replication-protocol",
-    "replication",
-    "binlog"
-  ],
   "type": "library",
   "require": {
-    "php": ">=8.1",
+    "php": "8.1.*",
     "ext-bcmath": "*",
     "ext-json": "*",
     "ext-sockets": "*",


### PR DESCRIPTION
The PHP version requirements have been specifically set to PHP 8.1.*. This slightly restricts our version compatibility but also ensures functional compatibility with the version specified. The keywords section in the composer.json file was also removed.