### PR TITLE
Downgrade "doctrine/collections" package version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "ext-bcmath": "*",
     "ext-json": "*",
     "ext-sockets": "*",
-    "doctrine/collections": "^2.1",
+    "doctrine/collections": "^1.8",
     "doctrine/dbal": "^3.8",
     "psr/log": "^3.0",
     "psr/simple-cache": "^3.0",


### PR DESCRIPTION
This commit downgrades the version of the "doctrine/collections" package from "^2.1" to "^1.8" in composer.json. The downgrade ensures compatibility across different parts of the project that rely on this package.