### PR TITLE
Update type hinting in ArrayCache and increment version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "supermetrics-public/php-mysql-replication",
   "description": "Pure PHP Implementation of MySQL replication protocol. This allow you to receive event like insert, update, delete with their data and raw SQL queries.",
   "type": "library",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "require": {
     "php": "8.1.*",
     "ext-bcmath": "*",
@@ -11,7 +11,7 @@
     "doctrine/collections": "^1.8",
     "doctrine/dbal": "^3.8",
     "psr/log": "^1 || ^2 || ^3",
-    "psr/simple-cache": "^1 || ^2 || ^3",
+    "psr/simple-cache": "^1.0",
     "symfony/event-dispatcher": "^6.0|^7.0"
   },
   "require-dev": {

--- a/src/MySQLReplication/Cache/ArrayCache.php
+++ b/src/MySQLReplication/Cache/ArrayCache.php
@@ -16,7 +16,7 @@ class ArrayCache implements CacheInterface
     ) {
     }
 
-    public function get(string $key, mixed $default = null): mixed
+    public function get($key, mixed $default = null): mixed
     {
         return $this->has($key) ? self::$tableMapCache[$key] : $default;
     }
@@ -33,7 +33,7 @@ class ArrayCache implements CacheInterface
         return true;
     }
 
-    public function getMultiple(iterable $keys, mixed $default = null): iterable
+    public function getMultiple($keys, $default = null): iterable
     {
         $data = [];
         foreach ($keys as $key) {
@@ -45,7 +45,7 @@ class ArrayCache implements CacheInterface
         return $data !== [] ? $data : (array)$default;
     }
 
-    public function setMultiple(iterable $values, null|int|DateInterval $ttl = null): bool
+    public function setMultiple($values, $ttl = null): bool
     {
         foreach ($values as $key => $value) {
             $this->set($key, $value);
@@ -54,7 +54,7 @@ class ArrayCache implements CacheInterface
         return true;
     }
 
-    public function set(string $key, mixed $value, null|int|DateInterval $ttl = null): bool
+    public function set($key, $value, $ttl = null): bool
     {
         // automatically clear table cache to save memory
         if (count(self::$tableMapCache) > $this->tableCacheSize) {
@@ -66,7 +66,7 @@ class ArrayCache implements CacheInterface
         return true;
     }
 
-    public function deleteMultiple(iterable $keys): bool
+    public function deleteMultiple($keys): bool
     {
         foreach ($keys as $key) {
             $this->delete($key);
@@ -75,7 +75,7 @@ class ArrayCache implements CacheInterface
         return true;
     }
 
-    public function delete(string $key): bool
+    public function delete($key): bool
     {
         unset(self::$tableMapCache[$key]);
 


### PR DESCRIPTION
Type hinting in ArrayCache class has been updated to be less strict, allowing more flexibility in data types. The project version has been incremented in composer.json from "1.0.3" to "1.0.4", and the PSR Simple Cache dependency version has been limited to "^1.0" for compatibility reasons.