### PR TITLE
Update package version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "supermetrics-public/php-mysql-replication",
   "description": "Pure PHP Implementation of MySQL replication protocol. This allow you to receive event like insert, update, delete with their data and raw SQL queries.",
   "type": "library",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "require": {
     "php": "8.1.*",
     "ext-bcmath": "*",


### PR DESCRIPTION
The version number for the library "supermetrics-public/php-mysql-replication" has been updated in the composer.json file, upgrading it from version 1.0.4 to version