### PR TITLE
Add config.platform.php entry to unblock Dependabot

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "supermetrics-public/php-mysql-replication",
   "description": "Pure PHP Implementation of MySQL replication protocol. This allow you to receive event like insert, update, delete with their data and raw SQL queries.",
   "type": "library",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "require": {
     "php": "8.1.*",
     "ext-bcmath": "*",
@@ -40,6 +40,9 @@
   },
   "minimum-stability": "stable",
   "config": {
+    "platform": {
+      "php": "8.1.16"
+    },
     "sort-packages": true
   },
   "scripts": {


### PR DESCRIPTION
In our main repos, Dependabot is stuck with "No update possible for \<package-name\>". At least previously, adding a `config.platform.php` entry has helped.